### PR TITLE
clrspy pstacks command

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,10 +11,10 @@ root = true
 # All Files
 [*]
 charset = utf-8
-end_of_line = crlf
+end_of_line = lf
 indent_style = space
 indent_size = 4
-insert_final_newline = false
+insert_final_newline = true
 trim_trailing_whitespace = true
 
 
@@ -148,7 +148,7 @@ csharp_prefer_braces = true:silent
 dotnet_sort_system_directives_first = true
 # C# formatting settings
 # https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#c-formatting-settings
-csharp_new_line_before_open_brace = types,local_functions,indexers,methods,control_blocks,events
+csharp_new_line_before_open_brace = types,methods,local_functions
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true

--- a/ClrSpy.sln
+++ b/ClrSpy.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28527.54
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{002EF252-4375-4EF8-A3B1-4CF69320B9C4}"
 EndProject
@@ -52,7 +52,6 @@ Global
 		{D31E2404-7E54-437F-8C2D-5F52DA043584}.Release|x86.ActiveCfg = Release|Any CPU
 		{D31E2404-7E54-437F-8C2D-5F52DA043584}.Release|x86.Build.0 = Release|Any CPU
 		{CBAF655A-FD2A-44C6-9D24-FA9AC7829F98}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{CBAF655A-FD2A-44C6-9D24-FA9AC7829F98}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CBAF655A-FD2A-44C6-9D24-FA9AC7829F98}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{CBAF655A-FD2A-44C6-9D24-FA9AC7829F98}.Debug|x64.Build.0 = Debug|Any CPU
 		{CBAF655A-FD2A-44C6-9D24-FA9AC7829F98}.Debug|x86.ActiveCfg = Debug|Any CPU

--- a/src/ClrSpy/App.cs
+++ b/src/ClrSpy/App.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Cronos;
@@ -16,127 +17,15 @@ using Serilog;
 
 namespace ClrSpy
 {
-    [Command(Name = "ClrSpy", Description = "CLR Monitoring Tool"), Subcommand(typeof(ParallelStacks))]
+    [Command(Name = "ClrSpy", Description = "CLR Monitoring Tool")]
+    [Subcommand(typeof(ParallelStacks), typeof(Heap))]
     public class App
     {
         private static TimeSpan Timeout = TimeSpan.FromSeconds(5);
 
-        public static Task<int> Main(string[] args) => CommandLineApplication.ExecuteAsync<App>(args);
-
-        private static ClrRuntime GetTargetRuntime(string target)
+        public static async Task<int> Main(string[] args)
         {
-            DataTarget dataTarget = null;
-            if (Path.GetExtension(target).ToUpper() == "DMP")
-                dataTarget = DataTarget.LoadCoreDump(target);
-            else {
-                int pid = int.TryParse(target, out var a) ? a : (Process.GetProcessesByName(target).FirstOrDefault()?.Id ?? throw new Exception($"Process '{ProcessName}' not found"));
-                dataTarget = DataTarget.AttachToProcess(pid, (uint)Timeout.TotalMilliseconds, AttachFlag.NonInvasive);
-            }
-            return dataTarget.ClrVersions[0].CreateRuntime();
-        }
-
-        [Command("parallel-stacks", Description = "Shows parallel stacks")]
-        public class ParallelStacks
-        {
-            [Argument(0, Description = "Process or dump")]
-            private string Target { get; }
-
-            private void OnExecute(IConsole console)
-            {
-                var runtime = GetTargetRuntime(Target);
-                var stacks = CallStacks.GetStackTrances(runtime);
-                console.Out.WriteTree(Tree.MergeChains(stacks));
-            }
-        }
-
-        [Option(Description = "Observable process", LongName = "process", ShortName = "p", ShowInHelpText = true)]
-        public string ProcessName { get; set; }
-
-        [Option(Description = "Cron schedule", LongName = "schedule", ShortName = "s", ShowInHelpText = true)]
-        public string Schedule { get; set; }
-
-        [Option(Description = "Output filename template. Default - don't create output files",
-            LongName = "output",
-            ShortName = "o",
-            ShowInHelpText = true)]
-        public string OutputFilenameTemplate { get; set; }
-
-
-        [Option(Description = "GC Gen to collect. Default - 'gen0, gen1, gen2'",
-            LongName = "gen",
-            ShortName = "g",
-            ShowInHelpText = true)]
-        public string GcGenerationsToCollect { get; set; } = "gen0, gen1, gen2";
-
-        [Option(Description = "Count of diff to display, default = -1, disabled, 0 - without limit",
-            LongName = "top",
-            ShortName = "t",
-            ShowInHelpText = true)]
-        public int PrintDiffLimit { get; set; } = -1;
-
-        private async Task OnExecuteAsync()
-        {
-            var closingAppCts = new CancellationTokenSource();
-            Init(closingAppCts);
-            var serviceCollection = new ServiceCollection()
-                .AddLogging(b => b.AddSerilog());
-
-            using (var serviceProvider = serviceCollection.BuildServiceProvider())
-            using (var scope = serviceProvider.CreateScope())
-            {
-                var pid = Process.GetProcessesByName(ProcessName).FirstOrDefault()?.Id;
-                if (pid == null)
-                {
-                    Log.Logger.Fatal("PID for process name '{ProcessName}' isn't found", ProcessName);
-                    Environment.Exit(-1);
-                }
-
-                var gensStr = GcGenerationsToCollect.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-                var listGenToConnect = new List<int>(3);
-                for (int i = 0; i < gensStr.Length; ++i)
-                {
-                    switch (gensStr[i].Trim().Last())
-                    {
-                        case '1':
-                            listGenToConnect.Add(1);
-                            break;
-                        case '2':
-                            listGenToConnect.Add(2);
-                            break;
-                        case '3':
-                            listGenToConnect.Add(3);
-                            break;
-                        default:
-                            {
-                                Log.Logger.Fatal("Can't parse '--gen' options. Input: ''", gensStr[i]);
-                                Environment.Exit(-1);
-
-                            }
-                            break;
-                    }
-                }
-                Log.Logger.Information("Started");
-                var guard = ActivatorUtilities.CreateInstance<ClrSpy>(scope.ServiceProvider, new ClrSpyConfiguration() {
-                    DatetimeAccessor = () => DateTimeOffset.Now,
-                    Pid = pid.Value,
-                    OutputFilenameTemplate = OutputFilenameTemplate,
-                    PrintDiffLimit = PrintDiffLimit,
-                    Schedule = string.IsNullOrWhiteSpace(Schedule)
-                        ? null
-                        : CronExpression.Parse(Schedule, CronFormat.IncludeSeconds),
-                    GcGenToCollect = listGenToConnect,
-                });
-
-                await guard.StartAsync(closingAppCts.Token);
-            }
-
-        }
-
-        private static void Init(CancellationTokenSource closingAppCts)
-        {
-            Environment.CurrentDirectory = Path.GetDirectoryName(typeof(App).Assembly.Location);
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-            {
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
                 Console.OutputEncoding = Encoding.UTF8;
             }
 
@@ -146,16 +35,133 @@ namespace ClrSpy
                                           outputTemplate: "[{Timestamp:HH:mm:ss.fff} {Level:u3}] {Message:lj}{NewLine}{Exception}")
                          .CreateLogger();
 
+            try {
+                return await CommandLineApplication.ExecuteAsync<App>(args);
+            }
+            catch (TargetInvocationException ex) {
+                Console.Error.WriteLine(ex.InnerException.Message);
+                return 1;
+            }
+            catch (Exception ex) {
+                Console.Error.WriteLine(ex.Message);
+                return 1;
+            }
+        }
 
+        private static ClrRuntime GetTargetRuntime(string target)
+        {
+            DataTarget dataTarget = null;
+            if (Path.GetExtension(target)?.ToUpper() == ".DMP") {
+                dataTarget = DataTarget.LoadCrashDump(target);
+            }
+            else if (target.StartsWith("core.")) {
+                dataTarget = DataTarget.LoadCoreDump(target);
+            }
+            else {
+                int pid = int.TryParse(target, out var a) ? a : (Process.GetProcessesByName(target).FirstOrDefault()?.Id ?? throw new Exception($"Process '{target}' not found"));
+                dataTarget = DataTarget.AttachToProcess(pid, (uint)Timeout.TotalMilliseconds, AttachFlag.NonInvasive);
+            }
+            return dataTarget.ClrVersions[0].CreateRuntime();
+        }
 
-            Log.Logger.Information("Press `Ctrl + C` or Enter to exit...");
+        [Command("pstacks", Description = "Shows parallel stacks")]
+        public class ParallelStacks
+        {
+            [Argument(0, Description = "Process name, PID or dump filename")]
+            private string Target { get; }
 
-            Console.CancelKeyPress += (s, e) => {
-                e.Cancel = true;
-                Log.Logger.Information("Stop executing. Wait...");
-                closingAppCts.Cancel();
-            };
+            private void OnExecute(IConsole console)
+            {
+                var runtime = GetTargetRuntime(Target);
+                console.Out.WriteLine("Parallel Stacks:\n");
+                console.Out.WriteTree(Tree.MergeChains(CallStacks.GetStackTraces(runtime)));
+            }
+        }
+
+        [Command("heap", Description = "Analyze Heap")]
+        public class Heap
+        {
+            [Argument(0, Description = "Process name, PID or dump filename")]
+            private string Target { get; }
+
+            [Option(Description = "Cron schedule", LongName = "schedule", ShortName = "s", ShowInHelpText = true)]
+            public string Schedule { get; set; }
+
+            [Option(Description = "Output filename template. Default - don't create output files",
+                LongName = "output",
+                ShortName = "o",
+                ShowInHelpText = true)]
+            public string OutputFilenameTemplate { get; set; }
+
+            [Option(Description = "GC Gen to collect. Default - 'gen0, gen1, gen2'",
+                LongName = "gen",
+                ShortName = "g",
+                ShowInHelpText = true)]
+            public string GcGenerationsToCollect { get; set; } = "gen0, gen1, gen2";
+
+            [Option(Description = "Count of diff to display, default = -1, disabled, 0 - without limit",
+                LongName = "top",
+                ShortName = "t",
+                ShowInHelpText = true)]
+            public int PrintDiffLimit { get; set; } = -1;
+
+            private async Task OnExecuteAsync()
+            {
+                var closingAppCts = new CancellationTokenSource();
+                Init(closingAppCts);
+                var serviceCollection = new ServiceCollection()
+                    .AddLogging(b => b.AddSerilog());
+
+                using (var serviceProvider = serviceCollection.BuildServiceProvider())
+                using (var scope = serviceProvider.CreateScope()) {
+                    var gensStr = GcGenerationsToCollect.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                    var listGenToConnect = new List<int>(3);
+                    for (int i = 0; i < gensStr.Length; ++i) {
+                        var ch = gensStr[i].Trim().Last();
+                        switch (ch) {
+                            case '1':
+                            case '2':
+                            case '3':
+                                listGenToConnect.Add(Convert.ToInt32(ch.ToString()));
+                                break;
+                            default: {
+                                    Log.Logger.Fatal("Can't parse '--gen' options. Input: ''", gensStr[i]);
+                                    Environment.Exit(-1);
+                                }
+                                break;
+                        }
+                    }
+                    Log.Logger.Information("Started");
+                    var spyConfig = new ClrSpyConfiguration {
+                        DatetimeAccessor = () => DateTimeOffset.Now,
+                        Runtime = GetTargetRuntime(Target),
+                        OutputFilenameTemplate = OutputFilenameTemplate,
+                        PrintDiffLimit = PrintDiffLimit,
+                        Schedule = string.IsNullOrWhiteSpace(Schedule)
+                                                ? null
+                                                : CronExpression.Parse(Schedule, CronFormat.IncludeSeconds)
+                    };
+                    foreach (var gen in listGenToConnect) {
+                        spyConfig.GcGenToCollect[gen] = true;
+                    }
+                    var guard = ActivatorUtilities.CreateInstance<ClrSpy>(scope.ServiceProvider, spyConfig);
+                    await guard.StartAsync(closingAppCts.Token);
+                }
+            }
+
+            private static void Init(CancellationTokenSource closingAppCts)
+            {
+                Environment.CurrentDirectory = Path.GetDirectoryName(typeof(App).Assembly.Location);
+
+                Log.Logger.Information("Press `Ctrl + C` or Enter to exit...");
+
+                Console.CancelKeyPress += (s, e) => {
+                    e.Cancel = true;
+                    Log.Logger.Information("Stop executing. Wait...");
+                    closingAppCts.Cancel();
+                };
+            }
+
         }
     }
-
 }

--- a/src/ClrSpy/CallStacks.cs
+++ b/src/ClrSpy/CallStacks.cs
@@ -1,0 +1,14 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Diagnostics.Runtime;
+
+namespace ClrSpy
+{
+    public static class CallStacks
+    {
+        public static IEnumerable<IEnumerable<object>> GetStackTrances(ClrRuntime runtime) =>
+            runtime.Threads.Select(t => t.EnumerateStackTrace().Reverse());
+    }
+}

--- a/src/ClrSpy/CallStacks.cs
+++ b/src/ClrSpy/CallStacks.cs
@@ -17,7 +17,7 @@ namespace ClrSpy
             if (name == null) {
                 var method = Frame.Method;
                 if (method == null) {
-                    name = base.ToString();
+                    name = Frame.ToString();
                 }
                 else {
                     var typename = method.Type.Name;

--- a/src/ClrSpy/CallStacks.cs
+++ b/src/ClrSpy/CallStacks.cs
@@ -6,9 +6,35 @@ using Microsoft.Diagnostics.Runtime;
 
 namespace ClrSpy
 {
+    public class StackFrameWrapper
+    {
+        public ClrStackFrame Frame { get; }
+
+        private string name;
+
+        public override string ToString()
+        {
+            if (name == null) {
+                var method = Frame.Method;
+                if (method == null) {
+                    name = base.ToString();
+                }
+                else {
+                    var typename = method.Type.Name;
+                    var lastDot = typename.LastIndexOf('.');
+                    name = $"{(lastDot >= 0 ? typename.Substring(lastDot + 1) : typename)}.{method.Name}";
+                }
+            }
+            return name;
+        }
+
+        public StackFrameWrapper(ClrStackFrame frame) => Frame = frame;
+    }
+
     public static class CallStacks
     {
-        public static IEnumerable<IEnumerable<object>> GetStackTrances(ClrRuntime runtime) =>
-            runtime.Threads.Select(t => t.EnumerateStackTrace().Reverse());
+        public static IEnumerable<StackFrameWrapper[]> GetStackTraces(ClrRuntime runtime) =>
+            runtime.Threads.Select(t => t.EnumerateStackTrace().Reverse().Select(o => new StackFrameWrapper(o)).ToArray())
+                .Where(o => o.Length > 0);
     }
 }

--- a/src/ClrSpy/ClrSpy.csproj
+++ b/src/ClrSpy/ClrSpy.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <StartupObject />
+    <LangVersion>8.0</LangVersion>
+    <NullableReferenceTypes>true</NullableReferenceTypes>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ClrSpy/ClrSpy.csproj
+++ b/src/ClrSpy/ClrSpy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <StartupObject />
   </PropertyGroup>

--- a/src/ClrSpy/TreeMerge.cs
+++ b/src/ClrSpy/TreeMerge.cs
@@ -1,0 +1,78 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClrSpy
+{
+    public static class Tree
+    {
+        public class Node
+        {
+            public string Name { get; internal set; }
+            public List<object> Objects { get; internal set; }
+            public int Weight => Objects.Count;
+            public List<Node> Children { get; internal set; }
+        }
+
+        private static List<Node> MergeTrees(IEnumerable<Node> trees)
+        {
+            var r = new List<Node>();
+            foreach (var node in trees) {
+                Node last = r.Count == 0 ? null : r.Last();
+                if (last?.Name == node.Name) {
+                    last.Objects = last.Objects.Concat(node.Objects).ToList();
+                    last.Children = last.Children.Concat(node.Children).ToList();
+                }
+                else {
+                    if (last?.Children.Count > 1) {
+                        last.Children = MergeTrees(last.Children);
+                    }
+                    r.Add(node);
+                }
+            }
+            return r.OrderByDescending(o => o.Weight).ToList();
+        }
+
+        public static List<Node> MergeChains(IEnumerable<IEnumerable<object>> chains)
+        {
+            var sorted = chains.Select(c => c.ToArray())
+                .Select(c => KeyValuePair.Create(string.Join(".", c.Select(o => o.ToString())), c))
+                .OrderBy(kv => kv.Key).Select(kv => kv.Value).ToArray();
+            var tree = sorted.Select(c => {
+                Node node = null;
+                for (int i = c.Length; --i >= 0;) {
+                    node = new Node {
+                        Name = c[i].ToString(),
+                        Objects = new List<object> { c[i] },
+                        Children = node != null ? new List<Node> { node } : null,
+                    };
+                }
+                return node;
+            }).ToArray();
+            return MergeTrees(tree);
+        }
+
+        public static void WriteTree(this TextWriter w, List<Node> tree, List<bool> parentLines = null)
+        {
+            for (int i = 0; i < tree.Count; ++i) {
+                var node = tree[i];
+                var isLast = i == tree.Count - 1;
+                if (parentLines != null) {
+                    foreach (var v in parentLines)
+                        Console.Write(v ? "│ " : "  ");
+                }
+                Console.Write(isLast ? "┕" : "├");
+                if (node.Weight > 1)
+                    Console.Write($"{node.Weight} ");
+                if (node.Children != null) {
+                    var childLines = parentLines.ToList();
+                    childLines.Add(!isLast);
+                    w.WriteTree(node.Children, childLines);
+                }
+            }
+        }
+    }
+}
+
+

--- a/src/ClrSpy/Utils.cs
+++ b/src/ClrSpy/Utils.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace ClrSpy
+{
+    public static class Std
+    {
+        public static T Exchange<T>(ref T obj, T newValue)
+        {
+            var r = obj;
+            obj = newValue;
+            return r;
+        }
+    }
+
+    public struct Foreground : IDisposable
+    {
+        ConsoleColor prevColor;
+
+        public void Dispose()
+        {
+            Console.ForegroundColor = prevColor;
+        }
+
+        public Foreground(ConsoleColor newColor)
+        {
+            prevColor = Console.ForegroundColor;
+            Console.ForegroundColor = newColor;
+        }
+    }
+}


### PR DESCRIPTION
**pstacks** command
+ improvements of **heap** command

Output of pstacks command is console presentation of tree, like following:
```
[DebuggerU2MCatchHandlerFrame] - 24 threads
[ContextTransitionFrame]
[DebuggerU2MCatchHandlerFrame]
│ ├[GCFrame] - 16 threads
│ │ ├ThreadHelper.ThreadStart - 14 threads
│ │ │ExecutionContext.Run
│ │ │ExecutionContext.Run
│ │ │ExecutionContext.RunInternal
│ │ │ ├SocketManager+<>c.cctor>b__49_0 - 4 threads
│ │ │ │SocketManager.WriteAllQueues
│ │ │ │Monitor.ObjWait
│ │ │ │[GCFrame]
│ │ │ │
│ │ │ ├SocketManager+<>c.cctor>b__49_0 - 3 threads
│ │ │ │SocketManager.WriteAllQueues
│ │ │ │Monitor.ObjWait
│ │ │ │[GCFrame]
│ │ │ │
│ │ │ ├EventLoopScheduler.Run - 2 threads
│ │ │ │ ├Scheduler.Invoke
│ │ │ │ │GCPausesMeter.MeasureLoop
│ │ │ │ │Thread.Sleep
│ │ │ │ │Thread.Sleep
│ │ │ │ │Thread.SleepInternal
│ │ │ │ │
│ │ │ │ └SemaphoreSlim.Wait
│ │ │ │  SemaphoreSlim.WaitUntilCountOrTimeout
│ │ │ │  Monitor.ObjWait
│ │ │ │  [GCFrame]
│ │ │ │
│ │ │ ├__Canon>.Run
│ │ │ │Monitor.ObjWait
│ │ │ │[GCFrame]
│ │ │ │
│ │ │ ├AsyncFlushHandler.Loop
│ │ │ │__Canon>.Dequeue
│ │ │ │Monitor.ObjWait
│ │ │ │[GCFrame]
│ │ │ │
│ │ │ ├EventLoopScheduler.Run
│ │ │ │SemaphoreSlim.Wait
│ │ │ │SemaphoreSlim.WaitUntilCountOrTimeout
│ │ │ │Monitor.ObjWait
│ │ │ │[GCFrame]
│ │ │ │
│ │ │ ├SocketManager+<>c.cctor>b__49_0
│ │ │ │SocketManager.WriteAllQueues
│ │ │ │Monitor.ObjWait
│ │ │ │[GCFrame]
│ │ │ │
│ │ │ └TagCountersReporter.TagCounterReporterLoop
│ │ │  WaitHandle.WaitOne
│ │ │  WaitHandle.WaitOne
│ │ │  WaitHandle.InternalWaitOne
│ │ │  WaitHandle.WaitOneNative
│ │ │

```