### PR TITLE
: implement pstacks & tasks commands

### DIFF
--- a/ClrSpy.sln
+++ b/ClrSpy.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28527.54
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{002EF252-4375-4EF8-A3B1-4CF69320B9C4}"
 EndProject
@@ -52,7 +52,6 @@ Global
 		{D31E2404-7E54-437F-8C2D-5F52DA043584}.Release|x86.ActiveCfg = Release|Any CPU
 		{D31E2404-7E54-437F-8C2D-5F52DA043584}.Release|x86.Build.0 = Release|Any CPU
 		{CBAF655A-FD2A-44C6-9D24-FA9AC7829F98}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{CBAF655A-FD2A-44C6-9D24-FA9AC7829F98}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CBAF655A-FD2A-44C6-9D24-FA9AC7829F98}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{CBAF655A-FD2A-44C6-9D24-FA9AC7829F98}.Debug|x64.Build.0 = Debug|Any CPU
 		{CBAF655A-FD2A-44C6-9D24-FA9AC7829F98}.Debug|x86.ActiveCfg = Debug|Any CPU

--- a/src/ClrSpy/App.cs
+++ b/src/ClrSpy/App.cs
@@ -90,7 +90,7 @@ namespace ClrSpy
             private void OnExecute(IConsole console)
             {
                 console.Out.WriteLine("Tasks:\n");
-                console.Out.WriteTasks(new TasksSpy(GetTargetRuntime(Target)).GetTasks());
+                console.Out.WriteGroupedTasks(new TasksSpy(GetTargetRuntime(Target)).GetTasks());
             }
         }
 

--- a/src/ClrSpy/App.cs
+++ b/src/ClrSpy/App.cs
@@ -64,7 +64,10 @@ namespace ClrSpy
             return dataTarget.ClrVersions[0].CreateRuntime();
         }
 
-        [Command("pstacks", Description = "Shows parallel stacks")]
+        [Command("pstacks",
+            Description = "Shows parallel stacks, represented as a tree. "
+                + "Stack traces merged by common part and sorted by number of threads sharing the same stack trace in descending order."
+            )]
         public class ParallelStacks
         {
             [Argument(0, Description = "Process name, PID or dump filename")]
@@ -78,7 +81,7 @@ namespace ClrSpy
             }
         }
 
-        [Command("tasks", Description = "Shows tasks")]
+        [Command("tasks", Description = "Shows list of ThreadPool and Timer tasks.")]
         public class TasksCommand
         {
             [Argument(0, Description = "Process name, PID or dump filename")]

--- a/src/ClrSpy/App.cs
+++ b/src/ClrSpy/App.cs
@@ -5,111 +5,27 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Cronos;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Diagnostics.Runtime;
 using Serilog;
 
 
 namespace ClrSpy
 {
+    [Command(Name = "ClrSpy", Description = "CLR Monitoring Tool")]
+    [Subcommand(typeof(ParallelStacks), typeof(Heap), typeof(TasksCommand))]
     public class App
     {
-        public static Task<int> Main(string[] args) => CommandLineApplication.ExecuteAsync<App>(args);
+        private static TimeSpan Timeout = TimeSpan.FromSeconds(5);
 
-
-        [Required]
-        [Option(Description = "Observable process", LongName = "process", ShortName = "p", ShowInHelpText = true)]
-        public string ProcessName { get; set; }
-
-        [Option(Description = "Cron schedule", LongName = "schedule", ShortName = "s", ShowInHelpText = true)]
-        public string Schedule { get; set; }
-
-        [Option(Description = "Output filename template. Default - don't create output files",
-            LongName = "output",
-            ShortName = "o",
-            ShowInHelpText = true)]
-        public string OutputFilenameTemplate { get; set; }
-
-
-        [Option(Description = "GC Gen to collect. Default - 'gen0, gen1, gen2'",
-            LongName = "gen",
-            ShortName = "g",
-            ShowInHelpText = true)]
-        public string GcGenerationsToCollect { get; set; } = "gen0, gen1, gen2";
-
-        [Option(Description = "Count of diff to display, default = -1, disabled, 0 - without limit",
-            LongName = "top",
-            ShortName = "t",
-            ShowInHelpText = true)]
-        public int PrintDiffLimit { get; set; } = -1;
-
-        private async Task OnExecuteAsync()
+        public static async Task<int> Main(string[] args)
         {
-            var closingAppCts = new CancellationTokenSource();
-            Init(closingAppCts);
-            var serviceCollection = new ServiceCollection()
-                .AddLogging(b => b.AddSerilog());
-
-            using (var serviceProvider = serviceCollection.BuildServiceProvider())
-            using (var scope = serviceProvider.CreateScope())
-            {
-
-                var pid = Process.GetProcessesByName(ProcessName).FirstOrDefault()?.Id;
-                if (pid == null)
-                {
-                    Log.Logger.Fatal("PID for process name '{ProcessName}' isn't found", ProcessName);
-                    Environment.Exit(-1);
-                }
-
-                var gensStr = GcGenerationsToCollect.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-                var listGenToConnect = new List<int>(3);
-                for (int i = 0; i < gensStr.Length; ++i)
-                {
-                    switch (gensStr[i].Trim().Last())
-                    {
-                        case '1':
-                            listGenToConnect.Add(1);
-                            break;
-                        case '2':
-                            listGenToConnect.Add(2);
-                            break;
-                        case '3':
-                            listGenToConnect.Add(3);
-                            break;
-                        default:
-                            {
-                                Log.Logger.Fatal("Can't parse '--gen' options. Input: ''", gensStr[i]);
-                                Environment.Exit(-1);
-
-                            }
-                            break;
-                    }
-                }
-                Log.Logger.Information("Started");
-                var guard = ActivatorUtilities.CreateInstance<ClrSpy>(scope.ServiceProvider, new ClrSpyConfiguration() {
-                    DatetimeAccessor = () => DateTimeOffset.Now,
-                    Pid = pid.Value,
-                    OutputFilenameTemplate = OutputFilenameTemplate,
-                    PrintDiffLimit = PrintDiffLimit,
-                    Schedule = string.IsNullOrWhiteSpace(Schedule)
-                        ? null
-                        : CronExpression.Parse(Schedule, CronFormat.IncludeSeconds),
-                    GcGenToCollect = listGenToConnect,
-                });
-
-                await guard.StartAsync(closingAppCts.Token);
-            }
-
-        }
-
-        private static void Init(CancellationTokenSource closingAppCts)
-        {
-            Environment.CurrentDirectory = Path.GetDirectoryName(typeof(App).Assembly.Location);
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-            {
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
                 Console.OutputEncoding = Encoding.UTF8;
             }
 
@@ -119,16 +35,146 @@ namespace ClrSpy
                                           outputTemplate: "[{Timestamp:HH:mm:ss.fff} {Level:u3}] {Message:lj}{NewLine}{Exception}")
                          .CreateLogger();
 
+            try {
+                return await CommandLineApplication.ExecuteAsync<App>(args);
+            }
+            catch (TargetInvocationException ex) {
+                Console.Error.WriteLine(ex.InnerException.Message);
+                return 1;
+            }
+            catch (Exception ex) {
+                Console.Error.WriteLine(ex.Message);
+                return 1;
+            }
+        }
 
+        private static ClrRuntime GetTargetRuntime(string target)
+        {
+            DataTarget dataTarget = null;
+            if (Path.GetExtension(target)?.ToUpper() == ".DMP") {
+                dataTarget = DataTarget.LoadCrashDump(target);
+            }
+            else if (target.StartsWith("core.")) {
+                dataTarget = DataTarget.LoadCoreDump(target);
+            }
+            else {
+                int pid = int.TryParse(target, out var a) ? a : (Process.GetProcessesByName(target).FirstOrDefault()?.Id ?? throw new Exception($"Process '{target}' not found"));
+                dataTarget = DataTarget.AttachToProcess(pid, (uint)Timeout.TotalMilliseconds, AttachFlag.NonInvasive);
+            }
+            return dataTarget.ClrVersions[0].CreateRuntime();
+        }
 
-            Log.Logger.Information("Press `Ctrl + C` or Enter to exit...");
+        [Command("pstacks", Description = "Shows parallel stacks")]
+        public class ParallelStacks
+        {
+            [Argument(0, Description = "Process name, PID or dump filename")]
+            private string Target { get; }
 
-            Console.CancelKeyPress += (s, e) => {
-                e.Cancel = true;
-                Log.Logger.Information("Stop executing. Wait...");
-                closingAppCts.Cancel();
-            };
+            private void OnExecute(IConsole console)
+            {
+                var runtime = GetTargetRuntime(Target);
+                console.Out.WriteLine("Parallel Stacks:\n");
+                console.Out.WriteTree(Tree.MergeChains(CallStacks.GetStackTraces(runtime)));
+            }
+        }
+
+        [Command("tasks", Description = "Shows tasks")]
+        public class TasksCommand
+        {
+            [Argument(0, Description = "Process name, PID or dump filename")]
+            private string Target { get; }
+
+            private void OnExecute(IConsole console)
+            {
+                console.Out.WriteLine("Tasks:\n");
+                console.Out.WriteTasks(new TasksSpy(GetTargetRuntime(Target)).GetTasks());
+            }
+        }
+
+        [Command("heap", Description = "Analyze Heap")]
+        public class Heap
+        {
+            [Argument(0, Description = "Process name, PID or dump filename")]
+            private string Target { get; }
+
+            [Option(Description = "Cron schedule", LongName = "schedule", ShortName = "s", ShowInHelpText = true)]
+            public string Schedule { get; set; }
+
+            [Option(Description = "Output filename template. Default - don't create output files",
+                LongName = "output",
+                ShortName = "o",
+                ShowInHelpText = true)]
+            public string OutputFilenameTemplate { get; set; }
+
+            [Option(Description = "GC Gen to collect. Default - 'gen0, gen1, gen2'",
+                LongName = "gen",
+                ShortName = "g",
+                ShowInHelpText = true)]
+            public string GcGenerationsToCollect { get; set; } = "gen0, gen1, gen2";
+
+            [Option(Description = "Count of diff to display, default = -1, disabled, 0 - without limit",
+                LongName = "top",
+                ShortName = "t",
+                ShowInHelpText = true)]
+            public int PrintDiffLimit { get; set; } = -1;
+
+            private async Task OnExecuteAsync()
+            {
+                var closingAppCts = new CancellationTokenSource();
+                Init(closingAppCts);
+                var serviceCollection = new ServiceCollection()
+                    .AddLogging(b => b.AddSerilog());
+
+                using (var serviceProvider = serviceCollection.BuildServiceProvider())
+                using (var scope = serviceProvider.CreateScope()) {
+                    var gensStr = GcGenerationsToCollect.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                    var listGenToConnect = new List<int>(3);
+                    for (int i = 0; i < gensStr.Length; ++i) {
+                        var ch = gensStr[i].Trim().Last();
+                        switch (ch) {
+                            case '1':
+                            case '2':
+                            case '3':
+                                listGenToConnect.Add(Convert.ToInt32(ch.ToString()));
+                                break;
+                            default: {
+                                    Log.Logger.Fatal("Can't parse '--gen' options. Input: ''", gensStr[i]);
+                                    Environment.Exit(-1);
+                                }
+                                break;
+                        }
+                    }
+                    Log.Logger.Information("Started");
+                    var spyConfig = new ClrSpyConfiguration {
+                        DatetimeAccessor = () => DateTimeOffset.Now,
+                        Runtime = GetTargetRuntime(Target),
+                        OutputFilenameTemplate = OutputFilenameTemplate,
+                        PrintDiffLimit = PrintDiffLimit,
+                        Schedule = string.IsNullOrWhiteSpace(Schedule)
+                                                ? null
+                                                : CronExpression.Parse(Schedule, CronFormat.IncludeSeconds)
+                    };
+                    foreach (var gen in listGenToConnect) {
+                        spyConfig.GcGenToCollect[gen] = true;
+                    }
+                    var guard = ActivatorUtilities.CreateInstance<ClrSpy>(scope.ServiceProvider, spyConfig);
+                    await guard.StartAsync(closingAppCts.Token);
+                }
+            }
+
+            private static void Init(CancellationTokenSource closingAppCts)
+            {
+                Environment.CurrentDirectory = Path.GetDirectoryName(typeof(App).Assembly.Location);
+
+                Log.Logger.Information("Press `Ctrl + C` or Enter to exit...");
+
+                Console.CancelKeyPress += (s, e) => {
+                    e.Cancel = true;
+                    Log.Logger.Information("Stop executing. Wait...");
+                    closingAppCts.Cancel();
+                };
+            }
+
         }
     }
-
 }

--- a/src/ClrSpy/CallStacks.cs
+++ b/src/ClrSpy/CallStacks.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Diagnostics.Runtime;
+
+namespace ClrSpy
+{
+    public class StackFrameWrapper
+    {
+        public ClrStackFrame Frame { get; }
+
+        private string name;
+
+        public override string ToString()
+        {
+            if (name == null) {
+                var method = Frame.Method;
+                if (method == null) {
+                    name = Frame.ToString();
+                }
+                else {
+                    var typename = method.Type.Name;
+                    var lastDot = typename.LastIndexOf('.');
+                    name = $"{(lastDot >= 0 ? typename.Substring(lastDot + 1) : typename)}.{method.Name}";
+                }
+            }
+            return name;
+        }
+
+        public StackFrameWrapper(ClrStackFrame frame) => Frame = frame;
+    }
+
+    public static class CallStacks
+    {
+        public static IEnumerable<StackFrameWrapper[]> GetStackTraces(ClrRuntime runtime) =>
+            runtime.Threads.Select(t => t.EnumerateStackTrace().Reverse().Select(o => new StackFrameWrapper(o)).ToArray())
+                .Where(o => o.Length > 0);
+    }
+}

--- a/src/ClrSpy/ClrMD-Drivers/ClrDriver.cs
+++ b/src/ClrSpy/ClrMD-Drivers/ClrDriver.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Diagnostics.Runtime;
+
+namespace ClrSpy
+{
+    public class ThreadPoolItem
+    {
+        public ulong Address;
+        public string MethodName;
+    }
+
+    public interface IClrDriver
+    {
+        IEnumerable<ulong> EnumerateManagedWorkItems();
+        IEnumerable<ulong> EnumerateTimerTasks();
+        ThreadPoolItem GetThreadPoolItem(ulong item);
+    }
+
+    public abstract class ClrDriver : IClrDriver
+    {
+        protected readonly ClrRuntime runtime;
+        protected readonly ClrHeap heap;
+        protected readonly ClrAppDomain domain;
+
+        protected abstract IEnumerable<ulong> EnumerateThreadPoolWorkQueue(ulong workQueueRef);
+
+        public IEnumerable<ulong> EnumerateManagedWorkItems()
+        {
+            ClrStaticField workQueueField = ClrMdUtils.GetCorlib(runtime).GetTypeByName("System.Threading.ThreadPoolGlobals")?.GetStaticFieldByName("workQueue");
+            if (workQueueField != null) {
+                object workQueueValue = workQueueField.GetValue(domain);
+                ulong workQueueRef = (workQueueValue == null) ? 0L : (ulong)workQueueValue;
+                if (workQueueRef != 0) {
+                    ClrType workQueueType = heap.GetObjectType(workQueueRef);                   // should be System.Threading.ThreadPoolWorkQueue
+                    if (workQueueType?.Name == "System.Threading.ThreadPoolWorkQueue") {
+                        foreach (var item in EnumerateThreadPoolWorkQueue(workQueueRef)) {
+                            yield return item;
+                        }
+                    }
+                }
+            }
+        }
+
+        public virtual IEnumerable<ulong> EnumerateTimerTasks() => throw new NotImplementedException();
+
+        protected string BuildDelegateMethodName(ClrType targetType, ulong action)
+        {
+            var typeAction = heap.GetObjectType(action);
+            var fieldMethodPtr = typeAction.GetFieldByName("_methodPtr");
+            var fieldMethodPtrAux = typeAction.GetFieldByName("_methodPtrAux");
+            var methodPtr = (ulong)(long)fieldMethodPtr.GetValue(action);
+            if (methodPtr == 0)
+                return null;
+
+            ClrMethod method = runtime.GetMethodByAddress(methodPtr)
+                ?? runtime.GetMethodByAddress((ulong)(long)fieldMethodPtrAux.GetValue(action));     // could happen in case of static method
+
+            // anonymous method
+            var methodTypeName = method.Type.Name;
+            var targetTypeName = targetType.Name;
+            return (methodTypeName != targetTypeName
+                    && targetTypeName != "System.Threading.WaitCallback"
+                    && !targetTypeName.StartsWith("System.Action<")  // method is implemented by an class inherited from targetType ... or a simple delegate indirection to a static/instance method
+                        ? $"({targetTypeName})" : "")
+                + $"{methodTypeName}.{method.Name}";
+        }
+
+        protected virtual ulong GetTaskAction(ulong task)
+        {
+            var typeTask = heap.GetTypeByName("System.Threading.Tasks.Task");
+            var fieldTaskAction = typeTask.GetFieldByName("m_action");
+            return (ulong)fieldTaskAction.GetValue(task);
+        }
+
+        protected string BuildMethodNameFromDelegate(ulong action, ulong task = 0)
+        {
+            var typeTask = heap.GetTypeByName("System.Threading.Tasks.Task");
+            var fieldTaskScheduler = typeTask.GetFieldByName("m_taskScheduler");
+            var typeDelegate = heap.GetTypeByName("System.Delegate");
+            var fieldDelegateTarget = typeDelegate.GetFieldByName("_target");
+
+            var r = " [no action]";
+            if (action != 0) {
+                var target = (ulong)fieldDelegateTarget.GetValue(action);
+                if (target == 0) {
+                    r = " [no target]";
+                }
+                else {
+                    r = BuildDelegateMethodName(heap.GetObjectType(target), action);
+                    if (r == "System.Runtime.CompilerServices.AsyncMethodBuilderCore+MoveNextRunner.Run") {
+                        var fieldStateMachine = heap.GetObjectType(target).GetFieldByName("m_stateMachine");
+                        var stateMachine = (ulong)fieldStateMachine.GetValue(target);
+                        var typeStateMachine = heap.GetObjectType(stateMachine);
+                        r = typeStateMachine.Name;
+                    }
+                    else if (task != 0) {
+                        // get the task scheduler if any
+                        var scheduler = (ulong)fieldTaskScheduler.GetValue(task);
+                        if (scheduler != 0) {
+                            var schedulerTypeName = heap.GetObjectType(scheduler).ToString();
+                            if (schedulerTypeName != "System.Threading.Tasks.ThreadPoolTaskScheduler")
+                                r = $"{r} [{schedulerTypeName}]";
+                        }
+                    }
+                }
+            }
+            return r;
+        }
+
+        protected ThreadPoolItem GetTask(ulong task)
+        {
+            ThreadPoolItem tpi = new ThreadPoolItem() {
+                Address = task,
+            };
+
+            // look for the context in m_action._target
+            var action = GetTaskAction(task);
+            tpi.MethodName = BuildMethodNameFromDelegate(action, task);
+            return tpi;
+        }
+
+        private ThreadPoolItem GetQueueUserWorkItemCallback(ulong wi)
+        {
+            var typeQueueUserWorkItemCallback = heap.GetTypeByName("System.Threading.QueueUserWorkItemCallback");
+            var fieldCallback = typeQueueUserWorkItemCallback.GetFieldByName("callback");
+            var typeWaitCallback = heap.GetTypeByName("System.Threading.WaitCallback");
+
+
+            ThreadPoolItem tpi = new ThreadPoolItem() {
+                Address = wi,
+            };
+
+            // look for the callback given to ThreadPool.QueueUserWorkItem()
+            var callback = (ulong)fieldCallback.GetValue(wi);
+            tpi.MethodName = BuildMethodNameFromDelegate(callback);
+            return tpi;
+        }
+
+        public ThreadPoolItem GetThreadPoolItem(ulong item)
+        {
+            var itemType = heap.GetObjectType(item);
+
+            switch (itemType.Name) {
+                case "System.Threading.Tasks.Task":
+                case "System.Threading.Tasks.Task+DelayPromise":
+                    return GetTask(item);
+                case "System.Threading.QueueUserWorkItemCallback":
+                    return GetQueueUserWorkItemCallback(item);
+                default:
+                    // create a raw information
+                    ThreadPoolItem tpi = new ThreadPoolItem() {
+                        Address = (ulong)item,
+                        MethodName = itemType.Name
+                    };
+                    return tpi;
+            }
+        }
+
+        /*
+        protected ulong TaskFromDelayPromise(ulong promise)
+        {
+            var typeDelayPromise = heap.GetTypeByName("System.Threading.Tasks.Task+DelayPromise");
+            var fieldContinuationObject = typeDelayPromise.GetFieldByName("m_continuationObject");
+
+            var continuation = (ulong)fieldContinuationObject.GetValue(promise);
+            var typeContinuation = heap.GetObjectType(continuation);
+            var fieldAction = typeContinuation.GetFieldByName("_target");
+
+            var target = fieldAction.GetValue(continuation);
+        }*/
+
+        public ClrDriver(ClrRuntime runtime) =>
+            (this.runtime, heap, domain) = (runtime, runtime.Heap, runtime.AppDomains[0]);
+
+    }
+}

--- a/src/ClrSpy/ClrMD-Drivers/ClrDriver.cs
+++ b/src/ClrSpy/ClrMD-Drivers/ClrDriver.cs
@@ -25,7 +25,7 @@ namespace ClrSpy
         protected readonly ClrHeap heap;
         protected readonly ClrAppDomain domain;
 
-        protected readonly ClrType typeTask, typeDelegate;
+        protected readonly ClrType typeTask, typeDelegate, typeDelayPromise;
         protected readonly ClrInstanceField fieldDelegateTarget, fieldTaskAction, fieldTaskScheduler;
 
         protected abstract IEnumerable<ulong> EnumerateThreadPoolWorkQueue(ulong workQueueRef);
@@ -169,29 +169,16 @@ namespace ClrSpy
             }
         }
 
-        /*
-        protected ulong TaskFromDelayPromise(ulong promise)
-        {
-            var typeDelayPromise = heap.GetTypeByName("System.Threading.Tasks.Task+DelayPromise");
-            var fieldContinuationObject = typeDelayPromise.GetFieldByName("m_continuationObject");
-
-            var continuation = (ulong)fieldContinuationObject.GetValue(promise);
-            var typeContinuation = heap.GetObjectType(continuation);
-            var fieldAction = typeContinuation.GetFieldByName("_target");
-
-            var target = fieldAction.GetValue(continuation);
-        }*/
-
         public ClrDriver(ClrRuntime runtime)
         {
             (this.runtime, heap, domain) = (runtime, runtime.Heap, runtime.AppDomains[0]);
 
             typeDelegate = heap.GetTypeByName("System.Delegate");
             fieldDelegateTarget = typeDelegate.GetFieldByName("_target");
-
             typeTask = heap.GetTypeByName("System.Threading.Tasks.Task");
             fieldTaskAction = typeTask.GetFieldByName("m_action");
             fieldTaskScheduler = typeTask.GetFieldByName("m_taskScheduler");
+            typeDelayPromise = heap.GetTypeByName("System.Threading.Tasks.Task+DelayPromise");
         }
     }
 }

--- a/src/ClrSpy/ClrMD-Drivers/NetCoreClrDriver.cs
+++ b/src/ClrSpy/ClrMD-Drivers/NetCoreClrDriver.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Microsoft.Diagnostics.Runtime;
+
+namespace ClrSpy
+{
+    public class NetCoreClrDriver : ClrDriver
+    {
+        private IEnumerable<ulong> EnumerateConcurrentQueue(ulong queueAddr)
+        {
+            var types = heap.EnumerateTypes();
+            var typeQueue = heap.GetObjectType(queueAddr);
+            var fieldHead = typeQueue.GetFieldByName("_head");
+            var fieldTail = typeQueue.GetFieldByName("_tail");
+            var head = (ulong)fieldHead.GetValue(queueAddr);
+            var tail = (ulong)fieldTail.GetValue(queueAddr);
+
+            var typeSegment = heap.GetObjectType(head);
+            var fieldNextSegment = typeSegment.GetFieldByName("_nextSegment");
+            var fieldHeadAndTail = typeSegment.GetFieldByName("_headAndTail");
+            var fieldSlots = typeSegment.GetFieldByName("_slots");
+            var fieldSlotsMask = typeSegment.GetFieldByName("_slotsMask");
+
+            var typeHeadAndTail = heap.GetTypeByName("System.Collections.Concurrent.PaddedHeadAndTail");
+            var fieldSegmentHead = typeHeadAndTail.GetFieldByName("Head");
+            var fieldSegmentTail = typeHeadAndTail.GetFieldByName("Tail");
+
+            var typeSlot = heap.GetTypeByName("System.Collections.Concurrent.ConcurrentQueueSegment+Slot");
+            var fieldItem = typeSlot.GetFieldByName("Item");
+
+            for (; ; head = (ulong)fieldNextSegment.GetValue(head)) {
+                var slots = (ulong)fieldSlots.GetValue(head);
+                var slotsType = heap.GetObjectType(slots);
+                var slotsMask = (int)fieldSlotsMask.GetValue(head);
+                var len = slotsType.GetArrayLength(slots);
+
+                var headAndTail = (ulong)fieldHeadAndTail.GetValue(head);
+
+                for (int h = (int)fieldSegmentHead.GetValue(headAndTail, true), t = (int)fieldSegmentTail.GetValue(headAndTail, true); h != t; h = (h + 1) % len) {
+                    var slot = slotsType.GetArrayElementAddress(slots, h);
+                    var item = (ulong)fieldItem.GetValue(slot, true);
+                    yield return item;
+                }
+
+                if (head == tail)
+                    break;
+            }
+        }
+
+        protected override IEnumerable<ulong> EnumerateThreadPoolWorkQueue(ulong workQueueRef)
+        {
+            var typeQueue = heap.GetObjectType(workQueueRef);
+            var fieldWorkItems = typeQueue.GetFieldByName("workItems");
+            return EnumerateConcurrentQueue((ulong)fieldWorkItems.GetValue(workQueueRef));
+        }
+
+        public NetCoreClrDriver(ClrRuntime runtime) : base(runtime) {}
+    }
+}

--- a/src/ClrSpy/ClrMD-Drivers/NetFrameworkClrDriver.cs
+++ b/src/ClrSpy/ClrMD-Drivers/NetFrameworkClrDriver.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Microsoft.Diagnostics.Runtime;
+
+namespace ClrSpy
+{
+    public class NetFrameworkClrDriver : ClrDriver
+    {
+        /*
+        protected override ulong GetTaskAction(ulong task)
+        {
+            var typeTask = heap.GetTypeByName("System.Threading.Tasks.Task");
+            var fieldTaskContinuationObject = typeTask.GetFieldByName("m_continuationObject");
+            return (ulong)fieldTaskContinuationObject.GetValue(task);
+        }*/
+
+        protected override IEnumerable<ulong> EnumerateThreadPoolWorkQueue(ulong workQueueRef)
+        {
+            var typeQueue = heap.GetObjectType(workQueueRef);
+            var fieldTail = typeQueue.GetFieldByName("queueTail");
+            var tail = (ulong)fieldTail.GetValue(workQueueRef);
+
+            var typeSegment = heap.GetObjectType(tail);
+            var fieldNext = typeSegment.GetFieldByName("Next");
+            var fieldIndexes = typeSegment.GetFieldByName("indexes");
+            var fieldNodes = typeSegment.GetFieldByName("nodes");
+
+            for (; tail != 0; tail = (ulong)fieldNext.GetValue(tail)) {
+                var indexes = (int)fieldIndexes.GetValue(tail);
+                var lower = indexes & 0xFFFF;
+                var upper = (indexes >> 16) & 0xFFFF;
+                var nodes = (ulong)fieldNodes.GetValue(tail);
+                var typeNodes = heap.GetObjectType(nodes);
+                for (int i = lower; i < upper; ++i) {
+                    var node = (ulong)typeNodes.GetArrayElementValue(nodes, i);
+                    yield return node;
+                }
+            }
+
+            var fieldAllThreadQueues = typeQueue.GetStaticFieldByName("allThreadQueues");
+            var allThreadQueues = (ulong)fieldAllThreadQueues.GetValue(domain);
+            var typeSparseArray = heap.GetObjectType(allThreadQueues);
+            var fieldMArray = typeSparseArray.GetFieldByName("m_array");
+            var marray = (ulong)fieldMArray.GetValue(allThreadQueues);
+            var typeMArray = heap.GetObjectType(marray);
+            var marrayLen = typeMArray.GetArrayLength(marray);
+
+            for (int i = 0; i < marrayLen; ++i) {
+                var workStealingQueue = (ulong)typeMArray.GetArrayElementValue(marray, i);
+                if (workStealingQueue != 0) {
+                    var typeWorkStealingQueue = heap.GetObjectType(workStealingQueue);
+                    var fieldSubArray = typeWorkStealingQueue.GetFieldByName("m_array");
+                    var subArray = (ulong)fieldSubArray.GetValue(workStealingQueue);
+                    var typeSubMArray = heap.GetObjectType(subArray);
+                    var subArrayLen = typeMArray.GetArrayLength(subArray);
+
+                    for (int j = 0; j < subArrayLen; ++j) {
+                        var node = (ulong)typeSubMArray.GetArrayElementValue(subArray, j);
+                        if (node != 0) {
+                            yield return node;
+                        }
+                    }
+                }
+            }
+        }
+
+        public override IEnumerable<ulong> EnumerateTimerTasks()
+        {
+            var typeTimerQueue = heap.GetTypeByName("System.Threading.TimerQueue");
+            var typeTimerQueueTimer = heap.GetTypeByName("System.Threading.TimerQueueTimer");
+            var fieldSQueue = typeTimerQueue.GetStaticFieldByName("s_queue");
+
+            var fieldTimers = typeTimerQueue.GetFieldByName("m_timers");
+            var fieldNext = typeTimerQueueTimer.GetFieldByName("m_next");
+            var fieldState = typeTimerQueueTimer.GetFieldByName("m_state");
+
+            if (fieldSQueue.IsInitialized(domain)) {
+                var timeQueue = (ulong)fieldSQueue.GetValue(domain);
+                for (ulong timer = (ulong)fieldTimers.GetValue(timeQueue); timer != 0; timer = (ulong)fieldNext.GetValue(timer)) {
+                    var state = (ulong)fieldState.GetValue(timer);
+                    yield return state;
+                }
+            }
+        }
+
+        public NetFrameworkClrDriver(ClrRuntime runtime) : base(runtime) {}
+    }
+}

--- a/src/ClrSpy/ClrMD-Drivers/NetFrameworkClrDriver.cs
+++ b/src/ClrSpy/ClrMD-Drivers/NetFrameworkClrDriver.cs
@@ -8,13 +8,9 @@ namespace ClrSpy
 {
     public class NetFrameworkClrDriver : ClrDriver
     {
-        /*
-        protected override ulong GetTaskAction(ulong task)
-        {
-            var typeTask = heap.GetTypeByName("System.Threading.Tasks.Task");
-            var fieldTaskContinuationObject = typeTask.GetFieldByName("m_continuationObject");
-            return (ulong)fieldTaskContinuationObject.GetValue(task);
-        }*/
+        protected readonly ClrType typeTimerQueue, typeTimerQueueTimer;
+        protected readonly ClrStaticField fieldSQueue;
+        protected readonly ClrInstanceField fieldTimers, fieldNext, fieldState;
 
         protected override IEnumerable<ulong> EnumerateThreadPoolWorkQueue(ulong workQueueRef)
         {
@@ -55,14 +51,6 @@ namespace ClrSpy
 
         public override IEnumerable<ulong> EnumerateTimerTasks()
         {
-            var typeTimerQueue = heap.GetTypeByName("System.Threading.TimerQueue");
-            var typeTimerQueueTimer = heap.GetTypeByName("System.Threading.TimerQueueTimer");
-            var fieldSQueue = typeTimerQueue.GetStaticFieldByName("s_queue");
-
-            var fieldTimers = typeTimerQueue.GetFieldByName("m_timers");
-            var fieldNext = typeTimerQueueTimer.GetFieldByName("m_next");
-            var fieldState = typeTimerQueueTimer.GetFieldByName("m_state");
-
             if (fieldSQueue.IsInitialized(domain)) {
                 var timeQueue = (ulong)fieldSQueue.GetValue(domain);
                 for (ulong timer = (ulong)fieldTimers.GetValue(timeQueue); timer != 0; timer = (ulong)fieldNext.GetValue(timer)) {
@@ -73,6 +61,14 @@ namespace ClrSpy
             }
         }
 
-        public NetFrameworkClrDriver(ClrRuntime runtime) : base(runtime) {}
+        public NetFrameworkClrDriver(ClrRuntime runtime) : base(runtime)
+        {
+            typeTimerQueue = heap.GetTypeByName("System.Threading.TimerQueue");
+            fieldSQueue = typeTimerQueue.GetStaticFieldByName("s_queue");
+            fieldTimers = typeTimerQueue.GetFieldByName("m_timers");
+            typeTimerQueueTimer = heap.GetTypeByName("System.Threading.TimerQueueTimer");
+            fieldNext = typeTimerQueueTimer.GetFieldByName("m_next");
+            fieldState = typeTimerQueueTimer.GetFieldByName("m_state");
+        }
     }
 }

--- a/src/ClrSpy/ClrMD-ThreadPool.cs
+++ b/src/ClrSpy/ClrMD-ThreadPool.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Microsoft.Diagnostics.Runtime;
+
+// This file containes implementation of ThreadPool WorkItem enumerator for .NET Core
+// May be removed when ClrMD will implement it.
+
+namespace ClrSpy
+{
+    internal class CoreManagedWorkItem : ManagedWorkItem
+    {
+        public CoreManagedWorkItem(ClrType type, ulong addr)
+        {
+            Type = type;
+            Object = addr;
+        }
+
+        public override ulong Object { get; }
+
+        public override ClrType Type { get; }
+    }
+
+    public class CoreThreadPool : ClrThreadPool
+    {
+        private readonly ClrRuntime runtime;
+        private readonly ClrHeap heap;
+        private readonly ClrAppDomain domain;
+        private readonly IClrDriver driver;
+
+        public override int TotalThreads { get; }
+        public override int RunningThreads { get; }
+        public override int IdleThreads { get; }
+        public override int MinThreads { get; }
+        public override int MaxThreads { get; }
+        public override int MinCompletionPorts { get; }
+        public override int MaxCompletionPorts { get; }
+        public override int CpuUtilization { get; }
+        public override int FreeCompletionPortCount { get; }
+        public override int MaxFreeCompletionPorts { get; }
+
+        public override IEnumerable<NativeWorkItem> EnumerateNativeWorkItems() => runtime.ThreadPool.EnumerateNativeWorkItems();
+
+        public override IEnumerable<ManagedWorkItem> EnumerateManagedWorkItems()
+        {
+            foreach (ulong obj in driver.EnumerateManagedWorkItems()) {
+                if (obj != 0) {
+                    ClrType type = heap.GetObjectType(obj);
+                    if (type != null)
+                        yield return new CoreManagedWorkItem(type, obj);
+                }
+            }
+        }
+
+        public CoreThreadPool(ClrRuntime runtime) {
+            (this.runtime, heap, domain) = (runtime, runtime.Heap, runtime.AppDomains[0]);
+            driver = new NetCoreClrDriver(runtime);
+
+            var tp = runtime.ThreadPool;
+
+            TotalThreads = tp.TotalThreads;
+            RunningThreads = tp.RunningThreads;
+            IdleThreads = tp.IdleThreads;
+            MinThreads = tp.MinThreads;
+            MaxThreads = tp.MaxThreads;
+            MinCompletionPorts = tp.MinCompletionPorts;
+            MaxCompletionPorts = tp.MaxCompletionPorts;
+            CpuUtilization = tp.CpuUtilization;
+            FreeCompletionPortCount = tp.FreeCompletionPortCount;
+            MaxFreeCompletionPorts = tp.MaxFreeCompletionPorts;
+        }
+    }
+}

--- a/src/ClrSpy/ClrMD-Utils.cs
+++ b/src/ClrSpy/ClrMD-Utils.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using Microsoft.Diagnostics.Runtime;
+
+namespace ClrSpy
+{
+    public static class ClrMdUtils
+    {
+        public static ClrModule GetCorlib(ClrRuntime runtime) =>
+            runtime.Modules.FirstOrDefault(module => {
+                var name = module.AssemblyName.ToLower();
+                return name.Contains("mscorlib.dll") || name.Contains("corelib.");
+            }) ?? throw new InvalidOperationException("Impossible to find mscorlib.dll");
+
+        private static readonly ConcurrentDictionary<ClrRuntime, CoreThreadPool> coreThreadPoolByRuntime = new ConcurrentDictionary<ClrRuntime, CoreThreadPool>();
+
+        public static ClrThreadPool ThreadPool(this ClrRuntime runtime) =>
+            (runtime.ClrInfo.Flavor == ClrFlavor.Core
+                || runtime.ClrInfo.Flavor == ClrFlavor.Desktop) //!!!D
+            ? coreThreadPoolByRuntime.GetOrAdd(runtime, _ => new CoreThreadPool(runtime))
+            : runtime.ThreadPool;
+    }
+}

--- a/src/ClrSpy/ClrSpy.csproj
+++ b/src/ClrSpy/ClrSpy.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <StartupObject />
-    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/src/ClrSpy/ClrSpy.csproj
+++ b/src/ClrSpy/ClrSpy.csproj
@@ -1,12 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <StartupObject />
+    <LangVersion>8.0</LangVersion>
+    <NullableReferenceTypes>true</NullableReferenceTypes>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DynaMD" Version="1.0.7.1" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.0-alpha" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.4.0-dev" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0-preview3-35497" />

--- a/src/ClrSpy/ClrSpy.csproj
+++ b/src/ClrSpy/ClrSpy.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <StartupObject />
-    <LangVersion>8.0</LangVersion>
-    <NullableReferenceTypes>true</NullableReferenceTypes>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/src/ClrSpy/Tasks.cs
+++ b/src/ClrSpy/Tasks.cs
@@ -17,9 +17,13 @@ namespace ClrSpy
 
         public IEnumerable<ThreadPoolItem> GetTasks()
         {
-            var workItems = clrDriver.EnumerateManagedWorkItems().ToArray(); //!!!T
+//            return stackTasks.Select(clrDriver.GetThreadPoolItem);
+
+            var workItems = clrDriver.EnumerateManagedWorkItems().ToArray(); //!!!
+            var stackTasks = clrDriver.EnumerateStackTasks().Take(10).ToArray(); //!!!
             var timerTasks = clrDriver.EnumerateTimerTasks();
-            return workItems.Concat(timerTasks).Select(clrDriver.GetThreadPoolItem);
+            return workItems.Concat(timerTasks).Concat(stackTasks)
+                .Select(clrDriver.GetThreadPoolItem);
         }
 
         public TasksSpy(ClrRuntime runtime) {

--- a/src/ClrSpy/Tasks.cs
+++ b/src/ClrSpy/Tasks.cs
@@ -2,10 +2,8 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
+using System.Text.RegularExpressions;
 using Microsoft.Diagnostics.Runtime;
-using Microsoft.Diagnostics.Runtime.Desktop;
 
 namespace ClrSpy
 {
@@ -31,11 +29,15 @@ namespace ClrSpy
 
     public static class TasksExtensions
     {
-        public static void WriteTasks(this TextWriter w, IEnumerable<ThreadPoolItem> tasks)
+        private static readonly Regex reAngleBrackets = new Regex(@"\+\<([^>]+)\>", RegexOptions.Compiled);
+
+        private static string MakeReadableTaskName(string s) =>
+            reAngleBrackets.Replace(s, ".$1.");
+
+        public static void WriteGroupedTasks(this TextWriter w, IEnumerable<ThreadPoolItem> tasks)
         {
-            foreach (var t in tasks) {
-                Console.WriteLine(t.MethodName);
-            }
+            foreach (var group in tasks.GroupBy(o => o.MethodName).OrderByDescending(g => g.Count()))
+                Console.WriteLine($"{group.Count()}\t{MakeReadableTaskName(group.Key)}");
         }
     }
 }

--- a/src/ClrSpy/Tasks.cs
+++ b/src/ClrSpy/Tasks.cs
@@ -17,12 +17,9 @@ namespace ClrSpy
 
         public IEnumerable<ThreadPoolItem> GetTasks()
         {
-//            return stackTasks.Select(clrDriver.GetThreadPoolItem);
-
-            var workItems = clrDriver.EnumerateManagedWorkItems().ToArray(); //!!!
-            var stackTasks = clrDriver.EnumerateStackTasks().Take(10).ToArray(); //!!!
+            var workItems = clrDriver.EnumerateManagedWorkItems();
             var timerTasks = clrDriver.EnumerateTimerTasks();
-            return workItems.Concat(timerTasks).Concat(stackTasks)
+            return workItems.Concat(timerTasks)
                 .Select(clrDriver.GetThreadPoolItem);
         }
 

--- a/src/ClrSpy/Tasks.cs
+++ b/src/ClrSpy/Tasks.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Diagnostics.Runtime;
+using Microsoft.Diagnostics.Runtime.Desktop;
+
+namespace ClrSpy
+{
+    public class TasksSpy
+    {
+        private readonly ClrRuntime runtime;
+        private readonly ClrHeap heap;
+        private readonly IClrDriver clrDriver;
+
+        public IEnumerable<ThreadPoolItem> GetTasks()
+        {
+            var workItems = clrDriver.EnumerateManagedWorkItems().ToArray(); //!!!T
+            var timerTasks = clrDriver.EnumerateTimerTasks();
+            return workItems.Concat(timerTasks).Select(clrDriver.GetThreadPoolItem);
+        }
+
+        public TasksSpy(ClrRuntime runtime) {
+            (this.runtime, heap) = (runtime, runtime.Heap);
+            clrDriver = runtime.ClrInfo.Flavor == ClrFlavor.Core ? (IClrDriver)new NetCoreClrDriver(runtime) : new NetFrameworkClrDriver(runtime);
+        }
+    }
+
+    public static class TasksExtensions
+    {
+        public static void WriteTasks(this TextWriter w, IEnumerable<ThreadPoolItem> tasks)
+        {
+            foreach (var t in tasks) {
+                Console.WriteLine(t.MethodName);
+            }
+        }
+    }
+}

--- a/src/ClrSpy/TreeMerge.cs
+++ b/src/ClrSpy/TreeMerge.cs
@@ -1,0 +1,100 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClrSpy
+{
+    public static class Tree
+    {
+        public class Node
+        {
+            public string Name { get; internal set; }
+            public List<object> Objects { get; internal set; }
+            public int Weight => Objects.Count;
+            public List<Node> Children { get; internal set; }
+        }
+
+        private static List<Node> MergeTrees(IEnumerable<Node> trees)
+        {
+            var r = new List<Node>();
+            foreach (var node in trees) {
+                Node last = r.Count == 0 ? null : r.Last();
+                if (last?.Name == node.Name) {
+                    last.Objects = last.Objects.Concat(node.Objects).ToList();
+                    if (last.Children != null || node.Children != null) {
+                        last.Children = MergeTrees((last.Children ?? new List<Node>()).Concat(node.Children ?? new List<Node>()));
+                    }
+                }
+                else {
+                    if (last?.Children.Count > 1) {
+                        last.Children = MergeTrees(last.Children);
+                    }
+                    r.Add(node);
+                }
+            }
+            return r.OrderByDescending(o => o.Weight).ToList();
+        }
+
+        public static List<Node> MergeChains(IEnumerable<IEnumerable<object>> chains)
+        {
+            var sorted = chains.Select(c => c.ToArray())
+                .Select(c => KeyValuePair.Create(string.Join(".", c.Select(o => o.ToString())), c))
+                .OrderBy(kv => kv.Key).Select(kv => kv.Value).ToArray();
+            var tree = sorted.Select(c => {
+                Node node = null;
+                for (int i = c.Length; --i >= 0;) {
+                    node = new Node {
+                        Name = c[i].ToString(),
+                        Objects = new List<object> { c[i] },
+                        Children = node != null ? new List<Node> { node } : null,
+                    };
+                }
+                return node;
+            }).ToArray();
+            return MergeTrees(tree);
+        }
+
+        public static void WriteTree(this TextWriter w, List<Node> tree) => WriteTree(w, tree, new List<bool>());
+
+        private static void WriteTree(this TextWriter w, List<Node> tree, List<bool> parentLines)
+        {
+            for (int i = 0; i < tree.Count; ++i) {
+                var node = tree[i];
+                bool isLast = i == tree.Count - 1;
+                bool isSimpleChain = false;
+                for (List<Node> children; ; node = children[0]) {
+                    foreach (var v in parentLines) {
+                        Console.Write(v ? "│ " : "  ");
+                    }
+                    if (parentLines.Count > 0) {
+                        Console.Write(isSimpleChain
+                            ? (isLast ? " " : "│")
+                            : isLast ? "└" : "├");
+                    }
+                    Console.Write(node.Name);
+                    children = node.Children;
+                    if (!isSimpleChain && node.Weight > 1)
+                        Console.Write($" - {node.Weight} threads");
+                    Console.WriteLine();
+                    if (children?.Count != 1) {
+                        if (children != null) {
+                            var childLines = parentLines.ToList();
+                            childLines.Add(!isLast);
+                            w.WriteTree(children, childLines);
+                        }
+                        if (isSimpleChain) {
+                            foreach (var v in parentLines)
+                                Console.Write(v ? "│ " : "  ");
+                            Console.WriteLine(isLast ? " " : "│");
+                        }
+                        break;
+                    }
+                    isSimpleChain = true;
+                }
+            }
+        }
+    }
+}
+
+

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -6,6 +6,9 @@
     <OutputPath>$(SolutionDir)artifacts\bin</OutputPath>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <ApplicationIcon>$(SolutionDir)docs\img\icon.ico</ApplicationIcon>
+    <LangVersion>8.0</LangVersion>
+    <NullableReferenceTypes>true</NullableReferenceTypes>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="All" />

--- a/tests/ClrSpy.Tests/ClrSpy.Tests.csproj
+++ b/tests/ClrSpy.Tests/ClrSpy.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ClrSpy\ClrSpy.csproj" />


### PR DESCRIPTION
**tasks** command:  enumerate pending tasks from ThreadPool & Timer's queue. Only .Net Framework runtime supported, as it seems that ClrMD implementation is not complete for .NET Core.

**pstacks** command:

Output of pstacks command is console presentation of tree, like following:

```
[DebuggerU2MCatchHandlerFrame] - 24 threads
[ContextTransitionFrame]
[DebuggerU2MCatchHandlerFrame]
│ ├[GCFrame] - 16 threads
│ │ ├ThreadHelper.ThreadStart - 14 threads
│ │ │ExecutionContext.Run
│ │ │ExecutionContext.Run
│ │ │ExecutionContext.RunInternal
│ │ │ ├SocketManager+<>c.cctor>b__49_0 - 4 threads
│ │ │ │SocketManager.WriteAllQueues
│ │ │ │Monitor.ObjWait
│ │ │ │[GCFrame]
│ │ │ │
│ │ │ ├SocketManager+<>c.cctor>b__49_0 - 3 threads
│ │ │ │SocketManager.WriteAllQueues
│ │ │ │Monitor.ObjWait
│ │ │ │[GCFrame]
│ │ │ │
│ │ │ ├EventLoopScheduler.Run - 2 threads
│ │ │ │ ├Scheduler.Invoke
│ │ │ │ │GCPausesMeter.MeasureLoop
│ │ │ │ │Thread.Sleep
│ │ │ │ │Thread.Sleep
│ │ │ │ │Thread.SleepInternal
│ │ │ │ │
│ │ │ │ └SemaphoreSlim.Wait
│ │ │ │  SemaphoreSlim.WaitUntilCountOrTimeout
│ │ │ │  Monitor.ObjWait
```